### PR TITLE
fix(db): avoid DB migration for every request, don't logging no record error

### DIFF
--- a/commands/exploit.go
+++ b/commands/exploit.go
@@ -104,6 +104,10 @@ func (p *FetchExploitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...inter
 		}
 		return subcommands.ExitFailure
 	}
+	if err := driver.MigrateDB(); err != nil {
+		log15.Error("Failed to migrate DB", "err", err)
+		return subcommands.ExitFailure
+	}
 
 	log15.Info("Fetching Exploit")
 	var exploits []models.Exploit

--- a/commands/searchExploit.go
+++ b/commands/searchExploit.go
@@ -131,6 +131,10 @@ func (p *SearchExploitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...inte
 		}
 		return subcommands.ExitFailure
 	}
+	if err := driver.MigrateDB(); err != nil {
+		log15.Error("Failed to migrate DB", "err", err)
+		return subcommands.ExitFailure
+	}
 
 	stype := c.SearchConf.SearchType
 	param := c.SearchConf.SearchParam

--- a/db/db.go
+++ b/db/db.go
@@ -34,11 +34,6 @@ func NewDB(dbType string, dbPath string, debugSQL bool) (driver DB, locked bool,
 		return nil, false, err
 	}
 
-	log15.Info("Migrating DB.", "db", driver.Name())
-	if err := driver.MigrateDB(); err != nil {
-		log15.Error("Failed to migrate db.", "err", err)
-		return driver, false, err
-	}
 	return driver, false, nil
 }
 

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -143,8 +143,10 @@ func (r *RDBDriver) GetExploitByID(exploitUniqueID string) []*models.Exploit {
 		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
 		e.OffensiveSecurity = os
 	}
-	if len(errs.GetErrors()) > 0 {
-		log15.Error("Failed to get exploit by CveID", "err", errs.Error())
+	for _, e := range errs.GetErrors() {
+		if !gorm.IsRecordNotFoundError(e) {
+			log15.Error("Failed to get exploit by ExploitDB-ID", "err", e)
+		}
 	}
 	return es
 }
@@ -211,8 +213,10 @@ func (r *RDBDriver) GetExploitByCveID(cveID string) []*models.Exploit {
 		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
 		e.OffensiveSecurity = os
 	}
-	if len(errs.GetErrors()) > 0 {
-		log15.Error("Failed to get exploit by CveID", "err", errs.Error())
+	for _, e := range errs.GetErrors() {
+		if !gorm.IsRecordNotFoundError(e) {
+			log15.Error("Failed to get exploit by CveID", "err", e)
+		}
 	}
 	return es
 }

--- a/server/server.go
+++ b/server/server.go
@@ -35,10 +35,23 @@ func Start(logDir string) error {
 		Output: f,
 	}))
 
+	driver, locked, err := db.NewDB(c.CommonConf.DBType, c.CommonConf.DBPath, c.CommonConf.DebugSQL)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to Open DB: %s", err)
+		if locked {
+			msg += " Close DB connection"
+		}
+		return fmt.Errorf("%s: %s", msg, err)
+	}
+
+	if err := driver.MigrateDB(); err != nil {
+		return err
+	}
+
 	// Routes
 	e.GET("/health", health())
-	e.GET("/cves/:cve", getExploitByCveID())
-	e.GET("/id/:id", getExploitByID())
+	e.GET("/cves/:cve", getExploitByCveID(driver))
+	e.GET("/id/:id", getExploitByID(driver))
 
 	bindURL := fmt.Sprintf("%s:%s", c.ServerConf.Bind, c.ServerConf.Port)
 	log15.Info("Listening...", "URL", bindURL)
@@ -53,20 +66,11 @@ func health() echo.HandlerFunc {
 	}
 }
 
-func getExploitByCveID() echo.HandlerFunc {
+func getExploitByCveID(driver db.DB) echo.HandlerFunc {
 	return func(context echo.Context) (err error) {
 		cve := context.Param("cve")
 		log15.Debug("Params", "CVE", cve)
 
-		driver, locked, err := db.NewDB(c.CommonConf.DBType, c.CommonConf.DBPath, c.CommonConf.DebugSQL)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to Open DB: %s", err)
-			if locked {
-				msg += " Close DB connection"
-			}
-			log15.Error(msg)
-			return context.JSON(http.StatusInternalServerError, nil)
-		}
 		exploits := driver.GetExploitByCveID(cve)
 		if err != nil {
 			log15.Error("Failed to get Exploit Info by CVE.", "err", err)
@@ -75,20 +79,11 @@ func getExploitByCveID() echo.HandlerFunc {
 	}
 }
 
-func getExploitByID() echo.HandlerFunc {
+func getExploitByID(driver db.DB) echo.HandlerFunc {
 	return func(context echo.Context) (err error) {
 		exploitDBID := context.Param("id")
 		log15.Debug("Params", "ExploitDBID", exploitDBID)
 
-		driver, locked, err := db.NewDB(c.CommonConf.DBType, c.CommonConf.DBPath, c.CommonConf.DebugSQL)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to Open DB: %s", err)
-			if locked {
-				msg += " Close DB connection"
-			}
-			log15.Error(msg)
-			return context.JSON(http.StatusInternalServerError, nil)
-		}
 		exploit := driver.GetExploitByID(exploitDBID)
 		if err != nil {
 			log15.Error("Failed to get Exploit Info by EDB-ID.", "err", err)


### PR DESCRIPTION
In the current implementation, migrate DB for every request.
It's enough only once at server startup.