### PR TITLE
delete paper info

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ $ curl http://127.0.0.1:1326/cves/CVE-2006-2896 | jq
         "port": ""
       },
       "shell_code": null,
-      "paper": null
     }
   }
 ]
@@ -289,7 +288,6 @@ $ curl http://127.0.0.1:1326/id/10180 | jq
         "port": ""
       },
       "shell_code": null,
-      "paper": null
     }
   },
   {
@@ -315,7 +313,6 @@ $ curl http://127.0.0.1:1326/id/10180 | jq
         "port": ""
       },
       "shell_code": null,
-      "paper": null
     }
   },
   {
@@ -341,7 +338,6 @@ $ curl http://127.0.0.1:1326/id/10180 | jq
         "port": ""
       },
       "shell_code": null,
-      "paper": null
     }
   }
 ]

--- a/commands/searchExploit.go
+++ b/commands/searchExploit.go
@@ -183,10 +183,6 @@ func (p *SearchExploitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...inte
 				fmt.Println("\n  - Exploit Code or Proof of Concept:")
 				fmt.Printf("    %s\n", os.ShellCode.ShellCodeURL)
 			}
-			if os.Paper != nil {
-				fmt.Println("\n  - Paper:")
-				fmt.Printf("    %s\n", os.Paper.PaperURL)
-			}
 		}
 		fmt.Println("---------------------------------------")
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -62,7 +62,6 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.OffensiveSecurity{},
 		&models.Document{},
 		&models.ShellCode{},
-		&models.Paper{},
 	).Error; err != nil {
 		return fmt.Errorf("Failed to migrate. err: %s", err)
 	}
@@ -72,7 +71,6 @@ func (r *RDBDriver) MigrateDB() error {
 	errs = errs.Add(r.conn.Model(&models.OffensiveSecurity{}).AddIndex("idx_offensive_secyrity_exploit_unique_id", "exploit_unique_id").Error)
 	errs = errs.Add(r.conn.Model(&models.Document{}).AddIndex("idx_exploit_document_exploit_unique_id", "exploit_unique_id").Error)
 	errs = errs.Add(r.conn.Model(&models.ShellCode{}).AddIndex("idx_exploit_shell_code_exploit_unique_id", "exploit_unique_id").Error)
-	errs = errs.Add(r.conn.Model(&models.Paper{}).AddIndex("idx_exploit_paper_exploit_unique_id", "exploit_unique_id").Error)
 
 	for _, e := range errs {
 		if e != nil {
@@ -106,7 +104,6 @@ func (r *RDBDriver) deleteAndInsertExploit(conn *gorm.DB, exploits []models.Expl
 		var errs gorm.Errors
 		errs = errs.Add(tx.Delete(models.Document{}).Error)
 		errs = errs.Add(tx.Delete(models.ShellCode{}).Error)
-		errs = errs.Add(tx.Delete(models.Paper{}).Error)
 		errs = errs.Add(tx.Delete(models.OffensiveSecurity{}).Error)
 		errs = errs.Add(tx.Delete(models.Exploit{}).Error)
 		errs = util.DeleteNil(errs)
@@ -140,7 +137,7 @@ func (r *RDBDriver) GetExploitByID(exploitUniqueID string) []*models.Exploit {
 	errs = errs.Add(r.conn.Where(&models.Exploit{ExploitUniqueID: exploitUniqueID}).Find(&es).Error)
 	for _, e := range es {
 		os := &models.OffensiveSecurity{}
-		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
+		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
 		e.OffensiveSecurity = os
 	}
 	for _, e := range errs.GetErrors() {
@@ -156,7 +153,6 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 	es := []*models.Exploit{}
 	docs := []*models.Document{}
 	shells := []*models.ShellCode{}
-	papers := []*models.Paper{}
 	offensiveSecurities := []*models.OffensiveSecurity{}
 	var errs gorm.Errors
 
@@ -164,7 +160,6 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 	errs = errs.Add(r.conn.Find(&offensiveSecurities).Error)
 	errs = errs.Add(r.conn.Find(&docs).Error)
 	errs = errs.Add(r.conn.Find(&shells).Error)
-	errs = errs.Add(r.conn.Find(&papers).Error)
 	if len(errs.GetErrors()) > 0 {
 		log15.Error("Failed to delete old records", "err", errs.Error())
 	}
@@ -179,11 +174,6 @@ func (r *RDBDriver) GetExploitAll() []*models.Exploit {
 			for _, s := range shells {
 				if o.ID == s.OffensiveSecurityID {
 					o.ShellCode = s
-				}
-			}
-			for _, p := range papers {
-				if o.ID == p.OffensiveSecurityID {
-					o.Paper = p
 				}
 			}
 			if e.ID == o.ExploitID {
@@ -210,7 +200,7 @@ func (r *RDBDriver) GetExploitByCveID(cveID string) []*models.Exploit {
 	errs = errs.Add(r.conn.Where(&models.Exploit{CveID: cveID}).Find(&es).Error)
 	for _, e := range es {
 		os := &models.OffensiveSecurity{}
-		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Preload("Paper").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
+		errs = errs.Add(r.conn.Preload("Document").Preload("ShellCode").Where(&models.OffensiveSecurity{ExploitUniqueID: e.ExploitUniqueID}).First(&os).Error)
 		e.OffensiveSecurity = os
 	}
 	for _, e := range errs.GetErrors() {

--- a/fetcher/exploit.go
+++ b/fetcher/exploit.go
@@ -29,10 +29,6 @@ func FetchExploitDB(deep bool) (exploits []models.Exploit, err error) {
 	if exploitShellCodeMap, err = FetchExploitShellCodeMap(); err != nil {
 		return nil, err
 	}
-	var exploitPaperMap map[string]*models.Paper
-	if exploitPaperMap, err = FetchExploitPaperMap(); err != nil {
-		return nil, err
-	}
 
 	var exploitDocMap map[string]*models.Document
 	if exploitDocMap, err = FetchExploitDocumentMap(); err != nil {
@@ -47,9 +43,6 @@ func FetchExploitDB(deep bool) (exploits []models.Exploit, err error) {
 	for id := range exploitShellCodeMap {
 		uniqExploitDBIDs[id] = struct{}{}
 	}
-	for id := range exploitPaperMap {
-		uniqExploitDBIDs[id] = struct{}{}
-	}
 	for id := range exploitDocMap {
 		uniqExploitDBIDs[id] = struct{}{}
 	}
@@ -59,9 +52,6 @@ func FetchExploitDB(deep bool) (exploits []models.Exploit, err error) {
 		if ok {
 			for _, cveID := range cveIDs {
 				var description string
-				if e, ok := exploitPaperMap[id]; ok {
-					description = e.Description
-				}
 				if e, ok := exploitShellCodeMap[id]; ok {
 					description = e.Description
 				}
@@ -81,7 +71,6 @@ func FetchExploitDB(deep bool) (exploits []models.Exploit, err error) {
 						ExploitUniqueID: id,
 						Document:        exploitDocMap[id],
 						ShellCode:       exploitShellCodeMap[id],
-						Paper:           exploitPaperMap[id],
 					},
 				}
 				exploits = append(exploits, exploit)
@@ -89,9 +78,6 @@ func FetchExploitDB(deep bool) (exploits []models.Exploit, err error) {
 		} else {
 			// No CveID
 			var description string
-			if e, ok := exploitPaperMap[id]; ok {
-				description = e.Description
-			}
 			if e, ok := exploitShellCodeMap[id]; ok {
 				description = e.Description
 			}
@@ -109,7 +95,6 @@ func FetchExploitDB(deep bool) (exploits []models.Exploit, err error) {
 				OffensiveSecurity: &models.OffensiveSecurity{
 					Document:  exploitDocMap[id],
 					ShellCode: exploitShellCodeMap[id],
-					Paper:     exploitPaperMap[id],
 				},
 			}
 			exploits = append(exploits, exploit)
@@ -275,24 +260,6 @@ func FetchExploitShellCodeMap() (exploitShellCodeMap map[string]*models.ShellCod
 		exploitShellCodeMap[shellCode.ExploitUniqueID] = shellCode
 	}
 	return exploitShellCodeMap, nil
-}
-
-// FetchExploitPaperMap :
-func FetchExploitPaperMap() (exploitPaperMap map[string]*models.Paper, err error) {
-	exploitPaperMap = map[string]*models.Paper{}
-	url := "https://raw.githubusercontent.com/offensive-security/exploitdb-papers/master/files_papers.csv"
-	log15.Info("Fetching", "URL", url)
-	cveCsv, err := util.FetchURL(url)
-	papers := []*models.Paper{}
-	if err := gocsv.UnmarshalBytes(cveCsv, &papers); err != nil {
-		return nil, err
-	}
-
-	for _, paper := range papers {
-		paper.PaperURL = "https://github.com/offensive-security/exploitdb-papers/" + paper.PaperURL
-		exploitPaperMap[paper.ExploitUniqueID] = paper
-	}
-	return exploitPaperMap, nil
 }
 
 // FetchExploitDocumentMap :

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -32,7 +32,6 @@ type OffensiveSecurity struct {
 	ExploitUniqueID string     `json:"exploit_unique_id"`
 	Document        *Document  `json:"document"`
 	ShellCode       *ShellCode `json:"shell_code"`
-	Paper           *Paper     `json:"paper"`
 }
 
 // Document :
@@ -60,19 +59,6 @@ type ShellCode struct {
 	Date                OffensiveSecurityTime `csv:"date" json:"date"`
 	Author              string                `csv:"author" json:"author"`
 	Platform            string                `csv:"platform" json:"platform"`
-}
-
-// Paper :
-// https://github.com/offensive-security/exploitdb-papers
-type Paper struct {
-	OffensiveSecurityID int64                 `sql:"type:bigint REFERENCES offensive_securities(id)" json:",omitempty"`
-	ExploitUniqueID     string                `csv:"id" json:"exploit_unique_id"`
-	PaperURL            string                `csv:"file" json:"paper_url"`
-	Description         string                `csv:"description" json:"description"`
-	Date                OffensiveSecurityTime `csv:"date" json:"date"`
-	Author              string                `csv:"author" json:"author"`
-	Platform            string                `csv:"platform" json:"platform"`
-	Language            string                `csv:"language" json:"language"`
 }
 
 // MitreXML :


### PR DESCRIPTION
fix #13

delete fetching paper information, because offensive-security/exploitdb-papers has deleted.

NOTE: When applying the changes, you need to delete the local db (go-exploitdb.sqlite3) once.