### PR TITLE
Fix bug that doesn't allow using http proxies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine as builder
 
 RUN apk add --no-cache make git gcc musl-dev
 
-ENV REPOSITORY github.com/prince-chrismc/go-exploitdb
+ENV REPOSITORY github.com/mozqnet/go-exploitdb
 COPY . $GOPATH/src/$REPOSITORY
 RUN cd $GOPATH/src/$REPOSITORY && make install
 

--- a/commands/exploit.go
+++ b/commands/exploit.go
@@ -91,6 +91,9 @@ func (p *FetchExploitCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...inter
 	c.CommonConf.HTTPProxy = p.HTTPProxy
 	c.CommonConf.Deep = p.Deep
 
+	viper.Set("http-proxy", p.HTTPProxy)
+	viper.Set("dbpath", p.DBPath)
+
 	util.SetLogger(p.LogDir, c.CommonConf.Quiet, c.CommonConf.Debug, p.LogJSON)
 	if !c.CommonConf.Validate() {
 		return subcommands.ExitUsageError


### PR DESCRIPTION
In util/util.go, function fetchURL tries to retrieve the http-proxy attribute from viper config, yet http-proxy is not set anywhere, leading to proxy being ignored.